### PR TITLE
Change the working dir to current dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Will not dump configuration data
 
 >--config [PATH]
 
-Specify which config directory should be used, defaults to latest.
+Specify which config directory should be used, defaults to `/DIR_OF_YOUR_SERVER_JAR_FILE/server_update`.
 
 # Examples:
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ Automatically check and download the latest version of the server:
 Download and install the latest build of version 1.13.2, without checking:
 >python server_update.py --no-check --version 1.13.2 [PATH]
 
+Download and install latest version, using data from a specific config directory:
+>python server_update.py --config '/custom/config/here/' [PATH]
+
 Install latest version, regardless of server version:
 >python server_update.py --no-load-config  --no-check [PATH]
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Where [PATH] is the path to your paperclip.jar file. More info on the paperclip.
 
 This command will do the following:
 
-1. Attempt to load configuration data from the config directory(~/.server_update). The configuration data contains the currently installed server version and build. If no configuration data is found, and version info is not supplied via the command line, then the version and build for the currently installed server will default to 0.
+1. Attempt to load configuration data from the config directory (defaults to `/DIR_OF_YOUR_SERVER_JAR_FILE/server_update`. You may also specify this, see options below). The configuration data contains the currently installed server version and build. If no configuration data is found, and version info is not supplied via the command line, then the version and build for the currently installed server will default to 0.
 2. Check for a new version/build using the [PaperMC download API](https://paper.readthedocs.io/en/latest/site/api.html#downloads-api).
 3. If a new version/build is available, the default version and build(usually the latest) will be installed. Alternatively, the user can be prompted to manually select which version/build they want to be installed(Will occur if the '--interactive' flag is passed).
 4. The selected version is downloaded to a temporary directory located somewhere on your computer(This directory is generated using the python tempfile module, meaning that it will be generated in a safe, unobtrusive manner, and will be automatically removed at termination of the script).
@@ -79,6 +79,10 @@ Will not load configuration data
 >-ndc, --no-dump-config
 
 Will not dump configuration data
+
+>--config [PATH]
+
+Specify which config directory should be used, defaults to latest.
 
 # Examples:
 

--- a/server_update.py
+++ b/server_update.py
@@ -340,7 +340,7 @@ class FileUtil:
 
         self.path = path  # Path to file being updated
         self.temp = None  # Tempdir instance
-        self._working_path = os.path.dirname(__file__) + '/server_update'  # Working directory path
+        self._working_path = os.path.join(os.path.dirname(__file__), 'server_update')  # Working directory path
 
     def create_temp_dir(self):
 

--- a/server_update.py
+++ b/server_update.py
@@ -340,7 +340,7 @@ class FileUtil:
 
         self.path = path  # Path to file being updated
         self.temp = None  # Tempdir instance
-        self._working_path = os.path.join(os.path.expanduser("~"), '.server_update')  # Working directory path
+        self._working_path = os.path.dirname(__file__) + '/server_update'  # Working directory path
 
     def create_temp_dir(self):
 

--- a/server_update.py
+++ b/server_update.py
@@ -340,7 +340,7 @@ class FileUtil:
 
         self.path = path  # Path to file being updated
         self.temp = None  # Tempdir instance
-        self._working_path = os.path.join(os.path.dirname(__file__), 'server_update')  # Working directory path
+        self._working_path = os.path.join(os.path.dirname(self.path), 'server_update')  # Working directory path
 
     def create_temp_dir(self):
 

--- a/server_update.py
+++ b/server_update.py
@@ -336,12 +336,12 @@ class FileUtil:
     Class for managing the creating/deleting/moving of server files
     """
 
-    def __init__(self, path):
+    def __init__(self, path, working_dir=None):
 
         self.path = path  # Path to file being updated
         self.temp = None  # Tempdir instance
-        self._working_path = os.path.join(os.path.dirname(self.path), 'server_update')  # Working directory path
-
+        self._working_path = os.path.join(os.path.dirname(self.path), 'server_update') if working_dir is None else working_dir
+        
     def create_temp_dir(self):
 
         """
@@ -646,10 +646,10 @@ class ServerUpdater:
     Class that binds all server updater classes together
     """
 
-    def __init__(self, path, version=None, build=None, config=True, prompt=True):
+    def __init__(self, path, version=None, build=None, config=True, prompt=True, working_dir=None):
 
         self.version = version  # Version of minecraft server we are running
-        self.fileutil = FileUtil(path)  # Fileutility instance
+        self.fileutil = FileUtil(path, working_dir)  # Fileutility instance
         self.buildnum = build  # Buildnum of the current server
         self._available_versions = []  # List of available versions
         self.prompt = prompt  # Weather to prompt the user for version selection
@@ -1029,11 +1029,12 @@ if __name__ == '__main__':
     parser.add_argument('-i', '--interactive', help='Prompts the user for the version they would like to install.', action='store_true')
     parser.add_argument('-nlc', '--no-load-config', help='Will not load config information', action='store_false')
     parser.add_argument('-ndc', '--no-dump-config', help="Will not dump configuration information.", action='store_false')
+    parser.add_argument('--config', help="Specify which config directory should be used", default='NONE')
 
     args = parser.parse_args()
 
     serv = ServerUpdater(args.path, config=args.no_load_config, prompt=args.interactive,
-                         version=args.iv, build=args.ib)
+                         version=args.iv, build=args.ib, working_dir=args.config.rstrip(os.path.sep))
 
     update_available = True
 

--- a/server_update.py
+++ b/server_update.py
@@ -340,7 +340,10 @@ class FileUtil:
 
         self.path = path  # Path to file being updated
         self.temp = None  # Tempdir instance
-        self._working_path = os.path.join(os.path.dirname(self.path), 'server_update') if working_dir is None else working_dir
+        if working_dir is None:
+            self._working_path = os.path.join(os.path.dirname(self.path), 'server_update') 
+        else:
+            self._working_path = working_dir.rstrip(os.path.sep)
         
     def create_temp_dir(self):
 
@@ -1034,7 +1037,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     serv = ServerUpdater(args.path, config=args.no_load_config, prompt=args.interactive,
-                         version=args.iv, build=args.ib, working_dir=args.config.rstrip(os.path.sep))
+                         version=args.iv, build=args.ib, working_dir=args.config)
 
     update_available = True
 


### PR DESCRIPTION
To save the temp and configuration file to the user's home dir will potentially pollute the user's environment, and this may have issues when someone running multiple servers under that user.

Change that to the current dir could isolate different servers' configurations and avoid changing files/folders which do not belong to the Minecraft server.