### PR TITLE
Support for reading paper versioning info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# Gitignore File
+
+# IntelliJ project files
+.idea
+*.iml
+out
+gen
+
+# Python Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Python Files
+__pycache__/
+*.py[cod]
+*$py.class

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+# INITIAL COMMIT
 # PaperMC-Update
 A simple CLI script for automating the checking, downloading, and installing of PaperMC server updates.
 NOTE: This script can only be used for updating a [PaperMC Minecraft Server](https://papermc.io/). I highly recommend their implementation, as it is incredibly fast, supports multiple plugin formats, and is highly customisable. Consider changing if any of that sounds good to you. You can find the PaperMC documentation [Here](https://paper.readthedocs.io/en/latest/), and you can find their github page [Here](https://github.com/PaperMC).

--- a/README.md
+++ b/README.md
@@ -1,32 +1,35 @@
-# INITIAL COMMIT
 # PaperMC-Update
 A simple CLI script for automating the checking, downloading, and installing of PaperMC server updates.
-NOTE: This script can only be used for updating a [PaperMC Minecraft Server](https://papermc.io/). I highly recommend their implementation, as it is incredibly fast, supports multiple plugin formats, and is highly customisable. Consider changing if any of that sounds good to you. You can find the PaperMC documentation [Here](https://paper.readthedocs.io/en/latest/), and you can find their github page [Here](https://github.com/PaperMC).
+
+NOTE: This script can only be used for updating a [PaperMC Minecraft Server](https://papermc.io/). I highly recommend 
+their implementation, as it is incredibly fast, supports multiple plugin formats, and is highly customisable. 
+Consider changing if any of that sounds good to you. You can find the PaperMC documentation 
+[Here](https://paper.readthedocs.io/en/latest/), and you can find their github page [Here](https://github.com/PaperMC).
 
 # Prerequisites
-You must have Python 3+ installed. It should come pre-installed on most systems. This script has no other dependencies, so all you need is python! Instructions for installation are below:
+You must have Python 3+ installed. It should come pre-installed on most systems. 
+This script has no other dependencies, so all you need is python! Instructions for installation are below:
 
 ## Linux:
 
 RPM:
 >yum install python3.7
 
-Or:
-
 Debian:
->apt install python 3.7
+>apt install python3.7
 
 (Or use whatever packet manager is installed on your system)
 ## MacOS:
 
->brew install python 3.7
+>brew install python3.7
 
 ## Windows:
 
-Windows users can download python [Here](https://www.python.org/downloads/). The installation is very straightforward, although we recommend you add python to your PATH environment variable, as this makes using python much easier.
+Windows users can download python [Here](https://www.python.org/downloads/). The installation is very straightforward, 
+although we recommend you add python to your PATH environment variable, as this makes using python much easier.
 
 More information on installing/configuring python can be found [Here](https://www.python.org/downloads/).
-(Any python version works, although I recommend python 3.7)
+(Any python 3 version works, although I recommend python 3.7)
 
 # Usage
 
@@ -34,56 +37,61 @@ You may run the command like so:
 
 > python server_update.py [PATH]
 
-Where [PATH] is the path to your paperclip.jar file. More info on the paperclip.jar format can be found [Here](https://paper.readthedocs.io/en/latest/about/structure.html#id2). If a new file is downloaded, it will be installed to this path under the same name.
+Where [PATH] is the path to your paperclip.jar file. More info on the paperclip.jar format can be found 
+[Here](https://paper.readthedocs.io/en/latest/about/structure.html#id2). If a new file is downloaded, 
+it will be installed to this path under the same name.
 
 This command will do the following:
 
-1. Attempt to load configuration data from the config directory (defaults to `/DIR_OF_YOUR_SERVER_JAR_FILE/server_update`. You may also specify this, see options below). The configuration data contains the currently installed server version and build. If no configuration data is found, and version info is not supplied via the command line, then the version and build for the currently installed server will default to 0.
+1. Attempt to load current paper version/build(`/PATH_TO_SERVER_JAR/version_history.json`. This script only supports official builds of the paper server, meaning that we may fail to read config information for un-official builds). If no configuration data is found, and version info is not supplied via the command line, then the version and build for the currently installed server will default to 0.
 2. Check for a new version/build using the [PaperMC download API](https://paper.readthedocs.io/en/latest/site/api.html#downloads-api).
-3. If a new version/build is available, the default version and build(usually the latest) will be installed. Alternatively, the user can be prompted to manually select which version/build they want to be installed(Will occur if the '--interactive' flag is passed).
+3. If a new version/build is available, the default version and build(usually the latest) will be installed. Alternatively, the user can be prompted to manually select which version/build they want to be installed. You can use the `--interactive` flag for this.
 4. The selected version is downloaded to a temporary directory located somewhere on your computer(This directory is generated using the python tempfile module, meaning that it will be generated in a safe, unobtrusive manner, and will be automatically removed at termination of the script).
 5. The currently installed version of the server is backed up to the temporary directory, and deleted. The newly downloaded server is moved from the temporary directory to the path of the old server, and will retain the name of the old server(If an error occurs for any reason during the instillation procedure, then the script will attempt to recover your backed up version of the old server from the temporary directory).
-6. Dumps the current configuration data into the config directory(Created if it does not exsist already). This saves the currently installed version and build, so it can be automatically checked at a later execution of the script.
-7. (Optional) - Deletes the config directory and all data within it. Will only occur only if the user issues the '--cleanup' argument.
 
+This is the default operation of this script. However, you can fine tune the update process using the command line options
+listed below.
 # Command Line Options:
 
 The following command line options are available:
 
+Sets the default value for the version to install, defaults to latest:
 >-v [VERSION], --version [VERSION]
 
-Sets the default value for the version to install, defaults to latest.
+Sets the default value for the build to install, defaults to latest:
 >-b [BUILD], --build [BUILD]
 
-Sets the default value for the build to install, defaults to latest.
+Sets the currently installed server version, ignores config data:
 >-iv [VERSION]
 
-Sets the currently installed server version, ignores config data.
+Sets the currently installed server build, ignores config data:
 >-ib [BUILD]
 
-Sets the currently installed server build, ignores config data.
->-C, --cleanup
-
-Deletes the config directory and all data within.
+Checks for an update, does not install:
 >-c, --check-only
 
-Checks for an update, does not install.
+Does not check for an update, skips to install:
 >-nc, --no-check
 
-Does not check for an update, skips to install.
+Prompts the user for the version they would like to install:
 >-i, --interactive
 
-Prompts the user for the version they would like to install.
+Will not load configuration data:
 >-nlc, --no-load-config
 
-Will not load configuration data
+## Deprecated Command Line Options
+
+The following command line options are deprecated. They are still included for backwards compatibility,
+but they do nothing and should not be used.
+
+Delete the config directory and all data within:
+>-C, --cleanup
+
+Will not dump configuration data:
 >-ndc, --no-dump-config
 
-Will not dump configuration data
-
+Specify which config directory should be used, defaults to `/DIR_OF_YOUR_SERVER_JAR_FILE/server_update`:
 >--config [PATH]
-
-Specify which config directory should be used, defaults to `/DIR_OF_YOUR_SERVER_JAR_FILE/server_update`.
 
 # Examples:
 
@@ -93,13 +101,10 @@ Automatically check and download the latest version of the server:
 Download and install the latest build of version 1.13.2, without checking:
 >python server_update.py --no-check --version 1.13.2 [PATH]
 
-Download and install latest version, using data from a specific config directory:
->python server_update.py --config '/custom/config/here/' [PATH]
-
 Install latest version, regardless of server version:
 >python server_update.py --no-load-config  --no-check [PATH]
 
-Install specific version, regardless of server version:
+Install specific version, regardless of installed version:
 >python server_update.py --no-load-config --no-check --version [VERSION TO INSTALL] --build [BUILD TO INSTALL] [PATH]
 
 Interactively select a version you want to install, regardless of server version:
@@ -108,10 +113,71 @@ Interactively select a version you want to install, regardless of server version
 Check to see if a newer version is available, does not install:
 >python server_update.py --check-only [PATH]
 
+# Notes on Deprecated Features
+
+In earlier versions of PaperMC-Update, the script would keep a config file in the users home directory
+(Or elsewhere if specified) containing version information on the server so it can be persistent across runs. 
+There were many problems with this: it created unnecessary files, it was inaccurate, 
+and it made using PaperMC-Update a lot more complicated. Now, we read version info from a file named 
+'version_history.json', which is kept in the root directory of the server, and is managed by the server itself. This 
+eliminates the need for 'script-generated configuration files', 
+and makes PaperMC-Update easier to use and more accurate.
+
+However, their are some things to keep in mind:
+
+## Official Builds
+
+As of now, PaperMC-Update only supports official builds of the server. As such, builds built locally or 
+builds downloaded from unofficial sources may not be supported, 
+due to the fact that the config file format might be different, meaning that we can't pull version information from it.
+
+This is something I would like to change at a later date if possible. If you have some insight into the format of 
+the config file across different builds, and have a way to identify and pull information from said file,
+the please open a pull request. I would be happy to look it over! Be sure to include an example copy of the config 
+file.
+
+If you are using this script and see any of the following messages:
+
+>Failed to load config data - Not in JSON format!
+
+>Failed to load config data - We want strings, not [DATATYPE_HERE]!
+
+>Unable to load config data - Invalid Format, we support official builds only!
+
+Then please open an issue with the following information:
+
+1. Description of what you were trying to do
+2. All command arguments used
+3. Version/build you were trying to install
+4. Version/build of the currently installed server(If you know it)
+5. A copy of your 'version_history.json'
+
+I can use this information to not only fix the problems you are facing, but implement support 
+for your build. 
+
+## Command Line Options
+
+The old command line options were for managing the configuration file, such as removing it, creating it, and
+dumping information to it. These features are now obsolete, but the command line options are included for 
+backwards compatibility. These options do not appear on the help menu and they do nothing, they are their only to
+prevent usage errors. It is highly recommended that you stop using these options, and update any scripts or
+implementations that use these features. These features might be removed in a later version if deemed necessary,
+so be warned.
+
 # Conclusion
 
-This script provides a simple method to check/download/install PaperMC server updates. You can add your command to the start of your startfile, to ensure that you are always running the latest version. If you are hosting a server for a freind/customer, you can use this script to manage the updating process for them, so they don't have to.
+This script provides a simple method to check/download/install PaperMC server updates. You can add your command to the beginning of your start file, to ensure that you are always running the latest server version. 
+If you are hosting a server for a friend/customer, you can use this script to manage the updating process for them, so they don't have to.
 
 # Issues/Bugs
 
 If you have any questions on usage, or you have found a bug, please open a github issue. I would be happy to help!
+
+If you are reporting a bug/error, be sure to include the following:
+
+1. Description of what you were doing
+2. All arguments used
+3. Version/build you are trying to install
+4. Version/build of the currently installed server(If you know it).
+5. Fail point
+6. Stack trace/error name(If provided, should be for most cases) 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,11 @@ so be warned.
 This script provides a simple method to check/download/install PaperMC server updates. You can add your command to the beginning of your start file, to ensure that you are always running the latest server version. 
 If you are hosting a server for a friend/customer, you can use this script to manage the updating process for them, so they don't have to.
 
+# Special Thanks
+
+[devStorm](https://github.com/developStorm) - Helped with configuration file management, and offered valuable insight
+into the paper versioning file.
+
 # Issues/Bugs
 
 If you have any questions on usage, or you have found a bug, please open a github issue. I would be happy to help!
@@ -179,5 +184,5 @@ If you are reporting a bug/error, be sure to include the following:
 2. All arguments used
 3. Version/build you are trying to install
 4. Version/build of the currently installed server(If you know it).
-5. Fail point
+5. Fail point(If provided, should be for most cases)
 6. Stack trace/error name(If provided, should be for most cases) 

--- a/server_update.py
+++ b/server_update.py
@@ -21,7 +21,7 @@ def error_report(exc, net=False):
     """
     Function for displaying error information to the terminal
     :param exc: Exception object
-    :param net: Weather to include network information
+    :param net: Whether to include network information
     :return:
     """
 
@@ -137,7 +137,7 @@ class Update:
 
         """
         Gets file from Paper API, and displays a progress bar
-        Write to the file specified in chunks, as to not fill up or memory
+        Write to the file specified in chunks, as to not fill up the memory
         :param version: Version to download
         :param build_num: Build to download
         :param path: Path to file to write to
@@ -336,15 +336,12 @@ class FileUtil:
     Class for managing the creating/deleting/moving of server files
     """
 
-    def __init__(self, path, working_dir=None):
+    def __init__(self, path):
 
         self.path = path  # Path to file being updated
         self.temp = None  # Tempdir instance
-        if working_dir is None:
-            self._working_path = os.path.join(os.path.dirname(self.path), 'server_update') 
-        else:
-            self._working_path = working_dir.rstrip(os.path.sep)
-        
+        self.version = 'version_history.json'  # Name of paper version file
+
     def create_temp_dir(self):
 
         """
@@ -365,104 +362,84 @@ class FileUtil:
 
         self.temp.close()
 
-    def create_working_dir(self):
-
-        """
-        Creates working directory in the users home folder
-        Checks if one exists already.
-        :return:
-        """
-
-        # Checking if working directory exists
-
-        if not os.path.isdir(self._working_path):
-
-            # Creating directory
-
-            os.mkdir(self._working_path, 0o755)
-
-        return
-
-    def cleanup_working_dir(self):
-
-        """
-        Cleanup and removes the current working directory
-        :return:
-        """
-
-        # Checking if directory exists:
-
-        print("# Cleaning working directory...")
-
-        if os.path.isdir(self._working_path):
-
-            # Removing directory
-
-            shutil.rmtree(self._working_path)
-
-        print("# Done cleaning working directory!")
-
-        return
-
     def load_config(self):
 
         """
-        Loads configuration info from config file
-        :return:
+        Loads configuration info from 'version.json' in the server directory
+        We only load version info if it's in the official format!
         """
 
-        print("# Loading configuration data...")
+        config = os.path.join(os.path.dirname(self.path), self.version)
 
-        if os.path.isfile(os.path.join(self._working_path, 'config.json')):
+        print("# Checking configuration file at [{}] ...".format(config))
 
-            # File exists, read data from it
+        if os.path.isfile(config):
 
-            file = open(os.path.join(self._working_path, 'config.json'), 'r')
+            # Exists and is file, read it
 
-            config = json.loads(file.read())
+            print("# Loading configuration data ...")
 
-            file.close()
+            try:
 
-            print("# Done loading configuration data!")
+                file = open(config, 'r')
 
-            return config['version'], config['build']
+                data = json.load(file)
 
-        # Could not find config file, return default vals
+            except Exception as e:
 
-        print("# Could not find configuration file.")
+                # Failed to load config data - not in JSON format
 
-        return '0', 0
+                print("# Failed to load config data - Not in JSON format!")
 
-    def dump_config(self, version, build):
+                return '0', 0
 
-        """
-        Dumps configuration data to file
-        :param version: Version server is on
-        :param build: Build server is on
-        :return:
-        """
+            # Read the data, and attempt to pull some info out of it
 
-        print("# Dumping configuration data...")
+            current = data['currentVersion']
 
-        if not os.path.isdir(self._working_path):
+            if type(current) != str:
 
-            print("# Creating working directory[{}]".format(self._working_path))
+                # We only accept strings:
 
-            # Directory does not exist, creating
+                print("# Failed to load config data - We want strings, not {}!".format(type(current)))
 
-            self.create_working_dir()
+                return '0', 0
 
-            print("# Done creating working directory!")
+            # Catch any exceptions due to weird format conventions:
 
-        config = open(os.path.join(self._working_path, 'config.json'), 'w')
+            try:
 
-        config.write(json.dumps({'version': version, 'build': build}))
+                # Splitting the data in two so we can pull some content out:
 
-        config.close()
+                build, version = current.split(" ", 1)
 
-        print("# Done dumping configuration data!")
+                # Getting build information:
 
-        return
+                build = int(build.split("-")[-1])
+
+                # Getting version information:
+
+                version = version[5:-1]
+
+            except Exception as e:
+
+                # Weird file content. Unable to get info.
+
+                print("# Unable to load config data - Invalid Format, we support official builds only!")
+
+                return '0', 0
+
+            # Returning version information:
+
+            print("# Done loading configuration data! ")
+
+            return version, build
+
+        else:
+
+            print("# Unable to load config data from file at [{}] - Not found/Not a file!".format(config))
+
+            return '0', 0
 
     def _fail_install(self, point):
 
@@ -474,7 +451,7 @@ class FileUtil:
 
         print("\n+==================================================+")
         print("> !ATTENTION! <")
-        print("A error occurred during the instillation, and we can not continue.")
+        print("An error occurred during the instillation, and we can not continue.")
         print("We will attempt to recover your previous instillation(If applicable)")
         print("Fail point: {}".format(point))
         print("Detailed error info below:")
@@ -588,7 +565,8 @@ class FileUtil:
         print("A failure has occurred during the instillation process.")
         print("I'm sure you can see the error information above.")
         print("This script will attempt to recover your old instillation.")
-        print("If this operation fails, check the github page for more info: https://github.com/Owen-Cochell/PaperMC-Update")
+        print("If this operation fails, check the github page for more info: "
+              "https://github.com/Owen-Cochell/PaperMC-Update")
 
         # Deleting file in root directory:
 
@@ -649,13 +627,13 @@ class ServerUpdater:
     Class that binds all server updater classes together
     """
 
-    def __init__(self, path, version=None, build=None, config=True, prompt=True, working_dir=None):
+    def __init__(self, path, version=None, build=None, config=True, prompt=True):
 
         self.version = version  # Version of minecraft server we are running
-        self.fileutil = FileUtil(path, working_dir)  # Fileutility instance
+        self.fileutil = FileUtil(path)  # Fileutility instance
         self.buildnum = build  # Buildnum of the current server
         self._available_versions = []  # List of available versions
-        self.prompt = prompt  # Weather to prompt the user for version selection
+        self.prompt = prompt  # Whether to prompt the user for version selection
 
         # Starting object
 
@@ -670,20 +648,23 @@ class ServerUpdater:
         :return:
         """
 
-        if config and self.version == 'NONE' and self.buildnum == 'NONE':
+        temp_version = '0'
+        temp_build = 0
+
+        if config:
 
             # Allowed to use configuration file
 
-            self.version, self.buildnum = self.fileutil.load_config()
+            temp_version, temp_build = self.fileutil.load_config()
 
         else:
 
-            # Setting true default values
+            # Skipping config file
 
-            print("# Skipping configuration file")
+            print("# Skipping configuration file!")
 
-            self.version = (self.version if self.version != 'NONE' else '0')
-            self.buildnum = (self.buildnum if self.buildnum != 'NONE' else 0)
+        self.version = (self.version if self.version != '0' else temp_version)
+        self.buildnum = (self.buildnum if self.buildnum != 0 else temp_build)
 
         print("\nServer Version Information:")
         print("  > Version: [{}]".format(self.version))
@@ -766,7 +747,6 @@ class ServerUpdater:
             # User wants default value:
 
             val = default
-
 
         if val == 'latest':
 
@@ -1007,37 +987,42 @@ if __name__ == '__main__':
     # Ran as script
 
     print("+==========================================================================+")
-    print("""|     _____                              __  __          __      __        |  
+    print('''|     _____                              __  __          __      __        |  
 |    / ___/___  ______   _____  _____   / / / /___  ____/ /___ _/ /____    |
-|    \__ \/ _ \/ ___/ | / / _ \/ ___/  / / / / __ \/ __  / __ `/ __/ _ \\   |
+|    \__ \/ _ \/ ___/ | / / _ \/ ___/  / / / / __ \/ __  / __ `/ __/ _ \   |
 |   ___/ /  __/ /   | |/ /  __/ /     / /_/ / /_/ / /_/ / /_/ / /_/  __/   |
 |  /____/\___/_/    |___/\___/_/      \____/ .___/\__,_/\__,_/\__/\___/    |
-|                                         /_/                              |""")
+|                                         /_/                              |''')
     print("+==========================================================================+")
-    print("\n[Minecraft Server Updater]")
+    print("\n[PaperMC Server Updater]")
     print("[Handles the checking, downloading, and instillation of server versions]")
     print("[Written by: Owen Cochell]\n")
 
     parser = argparse.ArgumentParser(description='Minecraft Server Updater.',
-                                     epilog="Please check the github page for more info: https://github.com/Owen-Cochell/PaperMC-Update.")
+                                     epilog="Please check the github page for more info: "
+                                            "https://github.com/Owen-Cochell/PaperMC-Update.")
 
     parser.add_argument('path', help='Path to file to be updated')
     parser.add_argument('-v', '--version', help='Server version to install(Sets default value)', default='latest')
     parser.add_argument('-b', '--build', help='Server build to install(Sets default value)',  default='latest')
-    parser.add_argument('-iv', help='Sets the currently installed server version, ignores config', default='NONE')
-    parser.add_argument('-ib', help='Sets the currently installed server build, ignores config.', default='NONE')
-    parser.add_argument('-C', '--cleanup', help='Deletes config directory and all sub-files', action='store_true')
+    parser.add_argument('-iv', help='Sets the currently installed server version, ignores config', default='0')
+    parser.add_argument('-ib', help='Sets the currently installed server build, ignores config.', default=0)
     parser.add_argument('-c', '--check-only', help='Checks for an update, does not install', action='store_true')
     parser.add_argument('-nc', '--no-check', help='Does not check for an update, skips to install', action='store_true')
-    parser.add_argument('-i', '--interactive', help='Prompts the user for the version they would like to install.', action='store_true')
-    parser.add_argument('-nlc', '--no-load-config', help='Will not load config information', action='store_false')
-    parser.add_argument('-ndc', '--no-dump-config', help="Will not dump configuration information.", action='store_false')
-    parser.add_argument('--config', help="Specify which config directory should be used", default='NONE')
+    parser.add_argument('-i', '--interactive', help='Prompts the user for the version they would like to install.',
+                        action='store_true')
+    parser.add_argument('-nlc', '--no-load-config', help='Will not load Paper version config.', action='store_false')
+
+    # Deprecated arguments - Included for compatibility, but do nothing
+
+    parser.add_argument('-ndc', '--no-dump-config', help=argparse.SUPPRESS, action='store_false')
+    parser.add_argument('--config', help=argparse.SUPPRESS, default='NONE')
+    parser.add_argument('-C', '--cleanup', help=argparse.SUPPRESS, action='store_true')
 
     args = parser.parse_args()
 
     serv = ServerUpdater(args.path, config=args.no_load_config, prompt=args.interactive,
-                         version=args.iv, build=args.ib, working_dir=args.config)
+                         version=args.iv, build=args.ib)
 
     update_available = True
 
@@ -1056,19 +1041,3 @@ if __name__ == '__main__':
         # Allowed to install/Can install
 
         serv.get_new(default_version=args.version, default_build=args.build)
-
-    # Checking if we can dump current configuration:
-
-    if args.no_dump_config and not args.check_only:
-
-        # We can dump our configuration data
-
-        serv.fileutil.dump_config(serv.version, serv.buildnum)
-
-    # Checking if we have to clean up:
-
-    if args.cleanup:
-
-        # Cleaning up
-
-        serv.fileutil.cleanup_working_dir()


### PR DESCRIPTION
Pull Request for implementing a feature that allows PaperMC-Update to read papermc versioning files, and pull versioning information from said files.

The following problems need to be addressed:

- [x] Method to extract version and build information from version.json
- [ ] Handel different naming conventions(Or stick to 'strict parsing', where if the .jar file is not from an official source we ignore the verion.json contents)
- [ ] Write over contents with new version info after the update(I personalty think we should let paper handle this when the server starts up, but thats just me)

I think we should handle the info in version.json using a method similar to how paper does it, but we should think about if we want to go for strict parsing, or something more dynamic(We can make some guesses or inferences regardless of the naming convention). 